### PR TITLE
Add view partials for repeated content on post or topic writer

### DIFF
--- a/machina/templates/machina/forum/forum_list.html
+++ b/machina/templates/machina/forum/forum_list.html
@@ -72,7 +72,7 @@
       <div class="py-2 col-md-1 d-none d-md-block text-center forum-count">{{ node.posts_count }}</div>
       <div class="py-2 col-md-2 col-sm-3 d-none d-sm-block forum-last-post">
         {% if node.last_post %}
-        {% include "partials/posted_by.html" with poster=node.last_post.poster username=node.last_post.username %}
+        {% include "partials/posted_by.html" with item=node.last_post %}
         &nbsp;<a href="{% url 'forum_conversation:topic' node.obj.slug node.obj.pk node.last_post.topic.slug node.last_post.topic.pk %}?post={{ node.last_post.pk }}#{{ node.last_post.pk }}"><i class="fas fa-arrow-circle-right "></i></a>
         <br />
         <small>{{ node.last_post.created }}</small>
@@ -136,7 +136,7 @@
       <div class="py-2 col-md-1 d-none d-md-block text-center forum-count">{{ node.posts_count }}</div>
       <div class="py-2 col-md-2 col-sm-3 d-none d-sm-block forum-last-post">
         {% if node.last_post %}
-        {% include "partials/posted_by.html" with poster=node.last_post.poster username=node.last_post.username %}
+        {% include "partials/posted_by.html" with item=node.last_post %}
         &nbsp;<a href="{% url 'forum_conversation:topic' node.obj.slug node.obj.pk node.last_post.topic.slug node.last_post.topic.pk %}?post={{ node.last_post.pk }}#{{ node.last_post.pk }}"><i class="fas fa-arrow-circle-right "></i></a>
         <br />
         <small>{{ node.last_post.created }}</small>

--- a/machina/templates/machina/forum/forum_list.html
+++ b/machina/templates/machina/forum/forum_list.html
@@ -72,16 +72,7 @@
       <div class="py-2 col-md-1 d-none d-md-block text-center forum-count">{{ node.posts_count }}</div>
       <div class="py-2 col-md-2 col-sm-3 d-none d-sm-block forum-last-post">
         {% if node.last_post %}
-        {% if node.last_post.poster %}
-        {% url 'forum_member:profile' node.last_post.poster_id as poster_url %}
-        {% blocktrans trimmed with poster_url=poster_url username=node.last_post.poster|forum_member_display_name %}
-        By: <a href="{{ poster_url }}">{{ username }}</a>
-        {% endblocktrans %}
-        {% else %}
-        {% blocktrans trimmed with poster_username=node.last_post.username %}
-        By: {{ poster_username }}
-        {% endblocktrans %}
-        {% endif %}
+        {% include "partials/posted_by.html" with poster=node.last_post.poster username=node.last_post.username %}
         &nbsp;<a href="{% url 'forum_conversation:topic' node.obj.slug node.obj.pk node.last_post.topic.slug node.last_post.topic.pk %}?post={{ node.last_post.pk }}#{{ node.last_post.pk }}"><i class="fas fa-arrow-circle-right "></i></a>
         <br />
         <small>{{ node.last_post.created }}</small>
@@ -145,16 +136,7 @@
       <div class="py-2 col-md-1 d-none d-md-block text-center forum-count">{{ node.posts_count }}</div>
       <div class="py-2 col-md-2 col-sm-3 d-none d-sm-block forum-last-post">
         {% if node.last_post %}
-        {% if node.last_post.poster_id %}
-        {% url 'forum_member:profile' node.last_post.poster_id as poster_url %}
-        {% blocktrans trimmed with poster_url=poster_url username=node.last_post.poster|forum_member_display_name %}
-        By: <a href="{{ poster_url }}">{{ username }}</a>
-        {% endblocktrans %}
-        {% else %}
-        {% blocktrans trimmed with poster_username=node.last_post.username %}
-        By: {{ poster_username }}
-        {% endblocktrans %}
-        {% endif %}
+        {% include "partials/posted_by.html" with poster=node.last_post.poster username=node.last_post.username %}
         &nbsp;<a href="{% url 'forum_conversation:topic' node.obj.slug node.obj.pk node.last_post.topic.slug node.last_post.topic.pk %}?post={{ node.last_post.pk }}#{{ node.last_post.pk }}"><i class="fas fa-arrow-circle-right "></i></a>
         <br />
         <small>{{ node.last_post.created }}</small>

--- a/machina/templates/machina/forum_conversation/post_create.html
+++ b/machina/templates/machina/forum_conversation/post_create.html
@@ -46,7 +46,7 @@
             <p><small class="text-muted">
             {% spaceless %}
               <i class="fa fa-clock-o"></i>&nbsp;
-              {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
+              {% include "partials/posted_by.html" with item=post show_creation_date=True%}
             {% endspaceless %}
             </small></p>
             <div class="post-content">
@@ -56,7 +56,7 @@
           </div>
           <div class="col-md-2 post-sidebar">
             <div class="username">
-              {% include "partials/posted_by.html" with poster=post.poster username=post.username username_highlighted=True no_trans=True %}
+              {% include "partials/posted_by.html" with item=post highlight_username=True show_by_prefix=True %}
             </div>
           </div>
         </div>

--- a/machina/templates/machina/forum_conversation/post_create.html
+++ b/machina/templates/machina/forum_conversation/post_create.html
@@ -46,16 +46,7 @@
             <p><small class="text-muted">
             {% spaceless %}
               <i class="fa fa-clock-o"></i>&nbsp;
-              {% if post.poster %}
-                {% url 'forum_member:profile' post.poster_id as poster_url %}
-                {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
-                  By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
-                {% endblocktrans %}
-              {% else %}
-                {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
-                  By: {{ poster_username }} on {{ creation_date }}
-                {% endblocktrans %}
-              {% endif %}
+              {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
             {% endspaceless %}
             </small></p>
             <div class="post-content">
@@ -64,7 +55,9 @@
             {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
           </div>
           <div class="col-md-2 post-sidebar">
-            <div class="username">{% if post.poster %}<a href="{% url 'forum_member:profile' post.poster_id %}"><b>{{ post.poster|forum_member_display_name }}</b></a>{% else %}<b>{{ post.username }}</b>{% endif %}</div>
+            <div class="username">
+              {% include "partials/posted_by.html" with poster=post.poster username=post.username username_highlighted=True no_trans=True %}
+            </div>
           </div>
         </div>
         {% endfor %}

--- a/machina/templates/machina/forum_conversation/topic_detail.html
+++ b/machina/templates/machina/forum_conversation/topic_detail.html
@@ -45,21 +45,14 @@
               </h4>
               {% endspaceless %}
               <p>
+              {% block written_by %}
                 <small class="text-muted">
                 {% spaceless %}
                 <i class="fas fa-clock"></i>&nbsp;
-                {% if post.poster %}
-                {% url 'forum_member:profile' post.poster_id as poster_url %}
-                {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
-                  By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
-                {% endblocktrans %}
-                {% else %}
-                {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
-                  By: {{ poster_username }} on {{ creation_date }}
-                {% endblocktrans %}
-                {% endif %}
+                {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
                 {% endspaceless %}
                 </small>
+              {% endblock %}
               </p>
               <div class="post-content">
                 {{ post.content.rendered }}
@@ -73,7 +66,7 @@
               {% if post.updates_count %}
               <div class="mt-4 edit-info">
                 <small class="text-muted">
-                  <i class="fas fa-edit"></i>&nbsp;{% if post.updated_by %}{% trans "Last edited by:" %}&nbsp;<a href="{% url 'forum_member:profile' post.updated_by_id %}">{{ post.updated_by|forum_member_display_name }}</a>&nbsp;{% else %}{% trans "Updated" %}&nbsp;{% endif %}{% trans "on" %}&nbsp;{{ post.updated }}, {% blocktrans count counter=post.updates_count %}edited {{counter }} time in total.{% plural %}edited {{counter }} times in total.{% endblocktrans %}
+                  <i class="fas fa-edit"></i>&nbsp;{% if post.updated_by %}{% trans "Last edited by:" %}&nbsp;{% include "partials/posted_by.html" with poster=post.updated_by no_trans=True%}&nbsp;{% else %}{% trans "Updated" %}&nbsp;{% endif %}{% trans "on" %}&nbsp;{{ post.updated }}, {% blocktrans count counter=post.updates_count %}edited {{counter }} time in total.{% plural %}edited {{counter }} times in total.{% endblocktrans %}
                 </small>
                 {% if post.update_reason %}
                 <br />
@@ -91,7 +84,7 @@
                 {% include "partials/avatar.html" with profile=post.poster.forum_profile show_placeholder=True %}
               </a>
             </div>
-            <div class="username"><a href="{% url 'forum_member:profile' post.poster_id %}"><b>{{ post.poster|forum_member_display_name }}</b></a></div>
+            <div class="username">{% include "partials/posted_by.html" with poster=post.poster username_highlighted=True no_trans=True %}</div>
             <div class="posts-count text-muted"><b>{% trans "Posts:" %}</b>&nbsp;{{ post.poster.forum_profile.posts_count }}</div>
             {% else %}
             <div class="username"><b>{{ post.username }}</b></div>

--- a/machina/templates/machina/forum_conversation/topic_detail.html
+++ b/machina/templates/machina/forum_conversation/topic_detail.html
@@ -49,7 +49,7 @@
                 <small class="text-muted">
                 {% spaceless %}
                 <i class="fas fa-clock"></i>&nbsp;
-                {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
+                {% include "partials/posted_by.html" with item=post show_creation_date=True%}
                 {% endspaceless %}
                 </small>
               {% endblock %}
@@ -66,7 +66,7 @@
               {% if post.updates_count %}
               <div class="mt-4 edit-info">
                 <small class="text-muted">
-                  <i class="fas fa-edit"></i>&nbsp;{% if post.updated_by %}{% trans "Last edited by:" %}&nbsp;{% include "partials/posted_by.html" with poster=post.updated_by no_trans=True%}&nbsp;{% else %}{% trans "Updated" %}&nbsp;{% endif %}{% trans "on" %}&nbsp;{{ post.updated }}, {% blocktrans count counter=post.updates_count %}edited {{counter }} time in total.{% plural %}edited {{counter }} times in total.{% endblocktrans %}
+                  <i class="fas fa-edit"></i>&nbsp;{% if post.updated_by %}{% trans "Last edited by:" %}&nbsp;{% include "partials/posted_by.html" with item=post.updated_by show_by_prefix=True%}&nbsp;{% else %}{% trans "Updated" %}&nbsp;{% endif %}{% trans "on" %}&nbsp;{{ post.updated }}, {% blocktrans count counter=post.updates_count %}edited {{counter }} time in total.{% plural %}edited {{counter }} times in total.{% endblocktrans %}
                 </small>
                 {% if post.update_reason %}
                 <br />
@@ -84,7 +84,7 @@
                 {% include "partials/avatar.html" with profile=post.poster.forum_profile show_placeholder=True %}
               </a>
             </div>
-            <div class="username">{% include "partials/posted_by.html" with poster=post.poster username_highlighted=True no_trans=True %}</div>
+            <div class="username">{% include "partials/posted_by.html" with item=post highlight_username=True show_by_prefix=True %}</div>
             <div class="posts-count text-muted"><b>{% trans "Posts:" %}</b>&nbsp;{{ post.poster.forum_profile.posts_count }}</div>
             {% else %}
             <div class="username"><b>{{ post.username }}</b></div>

--- a/machina/templates/machina/forum_conversation/topic_list.html
+++ b/machina/templates/machina/forum_conversation/topic_list.html
@@ -29,7 +29,7 @@
                 <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}" class="topic-name-link">{{ topic.subject }}</a>{% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" title="{% trans 'This topic is locked' %}"></i>{% endif %}
                 <div>
                   <div class="topic-created">
-                  {% include "partials/posted_by.html" with poster=topic.poster creation_date=topic.created username=topic.first_post.username %}
+                  {% include "partials/posted_by.html" with item=topic is_topic=True show_creation_date=True %}
                   </div>
                 </div>
               </td>
@@ -40,7 +40,7 @@
         <div class="py-2 col-md-1 d-none d-md-block text-center topic-count">{{ topic.views_count }}</div>
         <div class="py-2 col-md-2 col-sm-3 d-none d-sm-block topic-last-post">
         {% with last_post=topic.last_post %}
-          {% include "partials/posted_by.html" with poster=last_post.poster username=last_post.username %}
+          {% include "partials/posted_by.html" with item=last_post %}
           &nbsp;<a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}?post={{ last_post.pk }}#{{ last_post.pk }}"><i class="fas fa-arrow-circle-right "></i></a>
           <br />
           <small>{{ last_post.created }}</small>

--- a/machina/templates/machina/forum_conversation/topic_list.html
+++ b/machina/templates/machina/forum_conversation/topic_list.html
@@ -29,16 +29,7 @@
                 <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}" class="topic-name-link">{{ topic.subject }}</a>{% if topic.is_locked %}&nbsp;<i class="fas fa-times-circle locked-indicator" title="{% trans 'This topic is locked' %}"></i>{% endif %}
                 <div>
                   <div class="topic-created">
-                  {% if topic.poster %}
-                    {% url 'forum_member:profile' topic.poster_id as poster_url %}
-                    {% blocktrans trimmed with poster_url=poster_url username=topic.poster|forum_member_display_name creation_date=topic.created %}
-                      By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
-                    {% endblocktrans %}
-                  {% else %}
-                    {% blocktrans trimmed with poster_username=topic.first_post.username creation_date=topic.created %}
-                      By: {{ poster_username }} on {{ creation_date }}
-                    {% endblocktrans %}
-                  {% endif %}
+                  {% include "partials/posted_by.html" with poster=topic.poster creation_date=topic.created username=topic.first_post.username %}
                   </div>
                 </div>
               </td>
@@ -49,16 +40,7 @@
         <div class="py-2 col-md-1 d-none d-md-block text-center topic-count">{{ topic.views_count }}</div>
         <div class="py-2 col-md-2 col-sm-3 d-none d-sm-block topic-last-post">
         {% with last_post=topic.last_post %}
-          {% if last_post.poster %}
-            {% url 'forum_member:profile' last_post.poster_id as poster_url %}
-            {% blocktrans trimmed with poster_url=poster_url username=last_post.poster|forum_member_display_name %}
-              By: <a href="{{ poster_url }}">{{ username }}</a>
-            {% endblocktrans %}
-          {% else %}
-            {% blocktrans trimmed with poster_username=last_post.username %}
-              By: {{ poster_username }}
-            {% endblocktrans %}
-          {% endif %}
+          {% include "partials/posted_by.html" with poster=last_post.poster username=last_post.username %}
           &nbsp;<a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}?post={{ last_post.pk }}#{{ last_post.pk }}"><i class="fas fa-arrow-circle-right "></i></a>
           <br />
           <small>{{ last_post.created }}</small>

--- a/machina/templates/machina/forum_member/user_posts_list.html
+++ b/machina/templates/machina/forum_member/user_posts_list.html
@@ -46,10 +46,7 @@
                 <small class="text-muted">
                 {% spaceless %}
                 <i class="fas fa-clock"></i>&nbsp;
-                {% url 'forum_member:profile' post.poster_id as poster_url %}
-                {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
-                By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
-                {% endblocktrans %}
+                {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created %}
                 {% endspaceless %}
                 </small>
               </p>
@@ -63,7 +60,7 @@
                 {% include "partials/avatar.html" with profile=post.poster placeholder=False %}
               </a>
             </div>
-            <div class="username"><a href="{% url 'forum_member:profile' post.poster_id %}"><b>{{ post.poster|forum_member_display_name }}</b></a></div>
+            <div class="username">{% include "partials/posted_by.html" with poster=post.poster username_highlighted=True no_trans=True %}</div>
             <div class="posts-count text-muted"><b>{% trans "Posts:" %}</b>&nbsp;{{ post.poster.forum_profile.posts_count }}</div>
           </div>
         </div>

--- a/machina/templates/machina/forum_member/user_posts_list.html
+++ b/machina/templates/machina/forum_member/user_posts_list.html
@@ -46,7 +46,7 @@
                 <small class="text-muted">
                 {% spaceless %}
                 <i class="fas fa-clock"></i>&nbsp;
-                {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created %}
+                {% include "partials/posted_by.html" with item=post show_creation_date=True %}
                 {% endspaceless %}
                 </small>
               </p>
@@ -60,7 +60,7 @@
                 {% include "partials/avatar.html" with profile=post.poster placeholder=False %}
               </a>
             </div>
-            <div class="username">{% include "partials/posted_by.html" with poster=post.poster username_highlighted=True no_trans=True %}</div>
+            <div class="username">{% include "partials/posted_by.html" with item=post highlight_username=True show_by_prefix=True %}</div>
             <div class="posts-count text-muted"><b>{% trans "Posts:" %}</b>&nbsp;{{ post.poster.forum_profile.posts_count }}</div>
           </div>
         </div>

--- a/machina/templates/machina/forum_moderation/moderation_queue/detail.html
+++ b/machina/templates/machina/forum_moderation/moderation_queue/detail.html
@@ -81,16 +81,7 @@
               <small class="text-muted">
                 {% spaceless %}
                 <i class="fas fa-clock"></i>&nbsp;
-                {% if post.poster %}
-                {% url 'forum_member:profile' post.poster_id as poster_url %}
-                {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
-                By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
-                {% endblocktrans %}
-                {% else %}
-                {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
-                By: {{ poster_username }} on {{ creation_date }}
-                {% endblocktrans %}
-                {% endif %}
+                {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
                 {% endspaceless %}
               </small>
             </p>
@@ -113,7 +104,7 @@
               </a>
             </div>
             {% endif %}
-            <div class="username"><a href="{% url 'forum_member:profile' post.poster_id %}"><b>{{ post.poster|forum_member_display_name }}</b></a></div>
+            <div class="username">{% include "partials/posted_by.html" with poster=post.poster username_highlighted=True no_trans=True %}</div>
             <div class="posts-count text-muted"><b>{% trans "Posts:" %}</b>&nbsp;{{ post.poster.forum_profile.posts_count }}</div>
             {% else %}
             <div class="username"><b>{{ post.username }}</b></div>
@@ -140,16 +131,7 @@
             <p><small class="text-muted">
             {% spaceless %}
             <i class="fas fa-clock"></i>&nbsp;
-            {% if post.poster %}
-            {% url 'forum_member:profile' post.poster_id as poster_url %}
-            {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
-            By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
-            {% endblocktrans %}
-            {% else %}
-            {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
-            By: {{ poster_username }} on {{ creation_date }}
-            {% endblocktrans %}
-            {% endif %}
+            {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
             {% endspaceless %}
             </small></p>
             <div class="post-content">
@@ -158,7 +140,7 @@
             {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
           </div>
           <div class="col-md-2 post-sidebar">
-            <div class="username">{% if post.poster %}<a href="{% url 'forum_member:profile' post.poster_id %}"><b>{{ post.poster|forum_member_display_name }}</b></a>{% else %}<b>{{ post.username }}</b>{% endif %}</div>
+            <div class="username">{% include "partials/posted_by.html" with poster=post.poster username=post.username username_highlighted=True no_trans=True %}</div>
           </div>
         </div>
         {% endfor %}

--- a/machina/templates/machina/forum_moderation/moderation_queue/detail.html
+++ b/machina/templates/machina/forum_moderation/moderation_queue/detail.html
@@ -81,7 +81,7 @@
               <small class="text-muted">
                 {% spaceless %}
                 <i class="fas fa-clock"></i>&nbsp;
-                {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
+                {% include "partials/posted_by.html" with item=post show_creation_date=True%}
                 {% endspaceless %}
               </small>
             </p>
@@ -104,7 +104,7 @@
               </a>
             </div>
             {% endif %}
-            <div class="username">{% include "partials/posted_by.html" with poster=post.poster username_highlighted=True no_trans=True %}</div>
+            <div class="username">{% include "partials/posted_by.html" with item=post highlight_username=True show_by_prefix=True %}</div>
             <div class="posts-count text-muted"><b>{% trans "Posts:" %}</b>&nbsp;{{ post.poster.forum_profile.posts_count }}</div>
             {% else %}
             <div class="username"><b>{{ post.username }}</b></div>
@@ -131,7 +131,7 @@
             <p><small class="text-muted">
             {% spaceless %}
             <i class="fas fa-clock"></i>&nbsp;
-            {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
+            {% include "partials/posted_by.html" with item=post show_creation_date=True%}
             {% endspaceless %}
             </small></p>
             <div class="post-content">
@@ -140,7 +140,7 @@
             {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
           </div>
           <div class="col-md-2 post-sidebar">
-            <div class="username">{% include "partials/posted_by.html" with poster=post.poster username=post.username username_highlighted=True no_trans=True %}</div>
+            <div class="username">{% include "partials/posted_by.html" with item=post highlight_username=True show_by_prefix=True %}</div>
           </div>
         </div>
         {% endfor %}

--- a/machina/templates/machina/forum_moderation/moderation_queue/list.html
+++ b/machina/templates/machina/forum_moderation/moderation_queue/list.html
@@ -46,16 +46,9 @@
                   <a href="{% url 'forum_moderation:queued_post' post.pk %}" class="post-name-link">{{ post.subject }}</a>
                   <div>
                     <div class="post-created">
-                      {% if post.poster %}
-                      {% url 'forum_member:profile' post.poster_id as poster_url %}
-                      {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
-                      By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
-                      {% endblocktrans %}
-                      {% else %}
-                      {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
-                      By: {{ poster_username }} on {{ creation_date }}
-                      {% endblocktrans %}
-                      {% endif %}
+                    {% block written_by %}
+                      {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
+                    {% endblock %}
                     </div>
                   </div>
                 </td>

--- a/machina/templates/machina/forum_moderation/moderation_queue/list.html
+++ b/machina/templates/machina/forum_moderation/moderation_queue/list.html
@@ -47,7 +47,7 @@
                   <div>
                     <div class="post-created">
                     {% block written_by %}
-                      {% include "partials/posted_by.html" with poster=post.poster creation_date=post.created username=post.username %}
+                      {% include "partials/posted_by.html" with item=post show_creation_date=True %}
                     {% endblock %}
                     </div>
                   </div>

--- a/machina/templates/machina/forum_search/search.html
+++ b/machina/templates/machina/forum_search/search.html
@@ -78,16 +78,9 @@
               <a href="{% url 'forum_conversation:topic' result.forum_slug result.forum result.topic_slug result.topic %}" class="topic-name-link">{{ result.topic_subject }}</a>
               <div>
                 <div class="post-created">
-                  {% if result.poster %}
-                  {% url 'forum_member:profile' result.poster as poster_url %}
-                  {% blocktrans trimmed with poster_url=poster_url username=result.poster_name creation_date=result.created %}
-                  By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
-                  {% endblocktrans %}
-                  {% else %}
-                  {% blocktrans trimmed with poster_username=result.poster_name creation_date=result.created %}
-                  By: {{ poster_username }} on {{ creation_date }}
-                  {% endblocktrans %}
-                  {% endif %}
+                  {% block written_by %}
+                    {% include "partials/posted_by.html" with item=result show_creation_date=True is_search=True %}
+                  {% endblock %} 
                 </div>
               </div>
             </td>

--- a/machina/templates/machina/partials/posted_by.html
+++ b/machina/templates/machina/partials/posted_by.html
@@ -1,33 +1,59 @@
 {% load forum_member_tags %}
 {% load i18n %}
 
-{% if poster %}
-    {% url 'forum_member:profile' poster.id as profil_url %}
-    {% if no_trans %}
-        <a href="{{profil_url }}">{% if username_highlighted %}<b>{% endif %}{{ poster|forum_member_display_name  }}{% if username_highlighted %}</b>{% endif %}</a>
+{% if is_search %}
+    {% if item.poster %}
+        {% url 'forum_member:profile' item.poster as poster_url %}
+        {% blocktrans trimmed with username=item.poster_name creation_date=item.created %}
+            By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
+        {% endblocktrans %}
     {% else %}
-        {% if creation_date %}
-            {% blocktrans trimmed with username=poster|forum_member_display_name %}
-                By: <a href="{{ profil_url }}">{{ username }}</a> on {{ creation_date }}
-            {% endblocktrans %}
-        {% else %}    
-            {% blocktrans trimmed with username=poster|forum_member_display_name %}
-                    By: <a href="{{ profil_url }}">{{ username }}</a>
-            {% endblocktrans %}
-        {% endif %}
-    {% endif %}    
+        {% blocktrans trimmed with poster_username=item.poster_name creation_date=item.created %}
+        By: {{ poster_username }} on {{ creation_date }}
+        {% endblocktrans %}
+    {% endif %}
 {% else %}
-    {% if no_trans %}
-        {% if username_highlighted %}<b>{% endif %}{{ username }}{% if username_highlighted %}</b>{% endif %}
+    {% if item.poster %}
+        {% url 'forum_member:profile' item.poster_id as profil_url %}
+        {% if show_by_prefix %}
+            <a href="{{profil_url }}">{% if highlight_username %}<b>{% endif %}{{ item.poster|forum_member_display_name  }}{% if highlight_username %}</b>{% endif %}</a>
+        {% else %}
+            {% if show_creation_date %}
+                {% blocktrans trimmed with username=item.poster|forum_member_display_name creation_date=item.created %}
+                    By: <a href="{{ profil_url }}">{{ username }}</a> on {{ creation_date }}
+                {% endblocktrans %}
+            {% else %}    
+                {% blocktrans trimmed with username=item.poster|forum_member_display_name %}
+                        By: <a href="{{ profil_url }}">{{ username }}</a>
+                {% endblocktrans %}
+            {% endif %}
+        {% endif %}    
     {% else %}
-        {% if creation_date %}
-            {% blocktrans trimmed %}
-                By: {{ username }} on {{ creation_date }}
-            {% endblocktrans %}
-        {% else %}    
-            {% blocktrans trimmed %}
-                By: {{ username }}
-            {% endblocktrans %}
+        {% if show_by_prefix %}
+            {% if highlight_username %}<b>{% endif %}{{ username }}{% if highlight_username %}</b>{% endif %}
+        {% else %}
+            {% if show_creation_date %}
+                {% if is_topic %}
+                    {% blocktrans trimmed with username=topic.first_post.username creation_date=item.created %}
+                        By: {{ username }} on {{ creation_date }}
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans trimmed with username=item.username creation_date=item.created %}
+                        By: {{ username }} on {{ creation_date }}
+                    {% endblocktrans %}
+                {% endif %}
+            {% else %}    
+                {% if is_topic %}
+                    {% blocktrans trimmed with username=topic.first_post.username %}
+                        By: {{ username }}
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans trimmed with username=item.username %}
+                        By: {{ username }}
+                    {% endblocktrans %}
+                 {% endif %}    
+            {% endif %}
         {% endif %}
     {% endif %}
 {% endif %}
+

--- a/machina/templates/machina/partials/posted_by.html
+++ b/machina/templates/machina/partials/posted_by.html
@@ -1,0 +1,33 @@
+{% load forum_member_tags %}
+{% load i18n %}
+
+{% if poster %}
+    {% url 'forum_member:profile' poster.id as profil_url %}
+    {% if no_trans %}
+        <a href="{{profil_url }}">{% if username_highlighted %}<b>{% endif %}{{ poster|forum_member_display_name  }}{% if username_highlighted %}</b>{% endif %}</a>
+    {% else %}
+        {% if creation_date %}
+            {% blocktrans trimmed with username=poster|forum_member_display_name %}
+                By: <a href="{{ profil_url }}">{{ username }}</a> on {{ creation_date }}
+            {% endblocktrans %}
+        {% else %}    
+            {% blocktrans trimmed with username=poster|forum_member_display_name %}
+                    By: <a href="{{ profil_url }}">{{ username }}</a>
+            {% endblocktrans %}
+        {% endif %}
+    {% endif %}    
+{% else %}
+    {% if no_trans %}
+        {% if username_highlighted %}<b>{% endif %}{{ username }}{% if username_highlighted %}</b>{% endif %}
+    {% else %}
+        {% if creation_date %}
+            {% blocktrans trimmed %}
+                By: {{ username }} on {{ creation_date }}
+            {% endblocktrans %}
+        {% else %}    
+            {% blocktrans trimmed %}
+                By: {{ username }}
+            {% endblocktrans %}
+        {% endif %}
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
### Purpose
If we want to override the way the last writer of a post or a topic is shown, the project forces us to repeat
our modification in multiple templates. We would like to make it easier.

### Proposal
We introduce two different partials. One that writes the profile link and can be then easily overloaded and can be use on it's own.
The second that deals with the usual if/else written by for post or topic. It uses the profile link partial. 
It can be call with different option to take in charge the different cases of the project :
- username_put_forward : if username has to be put in bold
- creation_date :  if we show the creation date
- display_label_by : if false we won't display the usual label By:

To ease the overload, we've added a block when we could. Two files only call once the new partial so we introduce a block written_by around it. 
This way if we just want to change this in the template, we won't have to overload the whole file, just this block.
It's probably a case that will happen. For instance, in our personal use case, we will need to send an extra parameter to the partial.
